### PR TITLE
Update Scala, sbt, sbt plugins and dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # consul4s
  
-A native Scala client for interacting with Consul built on top of [sttp-client](https//github.com/softwaremill/sttp). 
+A native Scala client for interacting with Consul built on top of [sttp-client](https://github.com/softwaremill/sttp). 
 
 ## Features
 Currently `consul4s` supports these endpoints:

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,21 @@
 import ReleaseTransformations._
 
-lazy val refinedVersion = "0.9.14"
-lazy val sttpClientVersion = "2.0.0"
-lazy val kindProjectorVersion = "0.11.0"
+lazy val refinedVersion = "0.9.20"
+lazy val sttpClientVersion = "2.2.9"
+lazy val kindProjectorVersion = "0.11.3"
 lazy val circeVersion = "0.13.0"
-lazy val json4sVersion = "3.6.8"
-lazy val enumeratumVersion = "1.6.0"
-lazy val slf4jApiVersion = "1.7.25"
+lazy val json4sVersion = "3.6.10"
+lazy val enumeratumVersion = "1.6.1"
+lazy val slf4jApiVersion = "1.7.30"
 
-lazy val scalaTestVersion = "3.1.1"
-lazy val testContainersVersion = "0.36.0"
+lazy val scalaTestVersion = "3.2.3"
+lazy val testContainersVersion = "0.39.0"
 lazy val logbackVersion = "1.2.3"
 
 lazy val buildSettings = Seq(
   organization := "com.nryanov.consul4s",
-  scalaVersion := "2.13.2",
-  crossScalaVersions := Seq("2.12.10", "2.13.2")
+  scalaVersion := "2.13.4",
+  crossScalaVersions := Seq("2.12.13", "2.13.4")
 )
 
 lazy val noPublish = Seq(

--- a/modules/circe/src/main/scala/consul4s/circe/package.scala
+++ b/modules/circe/src/main/scala/consul4s/circe/package.scala
@@ -45,7 +45,7 @@ package object circe
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -56,7 +56,7 @@ package object circe
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -65,7 +65,7 @@ package object circe
       if (meta.code.code == 200 || meta.code.code == 409) {
         deserializeJson[A].apply(str).fold(err => Left(DeserializationError(str, err)), res => Right(res))
       } else {
-        Left[ResponseError[Exception], A](HttpError(str))
+        Left[ResponseError[Exception], A](HttpError(str, meta.code))
       }
     }
 

--- a/modules/core/src/main/scala/consul4s/v1/api/KVStore.scala
+++ b/modules/core/src/main/scala/consul4s/v1/api/KVStore.scala
@@ -99,7 +99,7 @@ trait KVStore[F[_]] { this: ConsulApi[F] =>
       } else if (meta.code.code == 404) { // If no key exists at the given path, a 404 is returned instead of a 200 response.
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[String]](HttpError(str))
+        Left[ResponseError[Exception], Option[String]](HttpError(str, meta.code))
       }
     })
 

--- a/modules/core/src/main/scala/consul4s/v1/api/package.scala
+++ b/modules/core/src/main/scala/consul4s/v1/api/package.scala
@@ -26,7 +26,7 @@ package object api {
         if (meta.isSuccess) {
           Right(())
         } else {
-          Left[ResponseError[Exception], Unit](HttpError(str))
+          Left[ResponseError[Exception], Unit](HttpError(str, meta.code))
         }
     }
 
@@ -65,7 +65,7 @@ package object api {
         cacheControlHeader match {
           case Some(value) =>
             val newUri: Identity[Uri] = request.uri.querySegment(Value("cached"))
-            val newHeaders = request.headers ++ Seq(Header.notValidated("Cache-Control", value))
+            val newHeaders = request.headers ++ Seq(Header("Cache-Control", value))
             request.copy(uri = newUri, headers = newHeaders)
           case None =>
             val newUri: Identity[Uri] = request.uri.querySegment(Value("cached"))
@@ -80,7 +80,7 @@ package object api {
       request: RequestT[Identity, Either[ResponseError[Exception], A], Nothing],
       token: String
     ): RequestT[Identity, Either[ResponseError[Exception], A], Nothing] =
-      request.copy(headers = request.headers ++ Seq(Header.notValidated("X-Consul-Token", token)))
+      request.copy(headers = request.headers ++ Seq(Header("X-Consul-Token", token)))
 
     private def makeBody(f: => String): F[String] = sttpBackend.responseMonad.eval(f)
   }

--- a/modules/core/src/test/scala/consul4s/BaseSpec.scala
+++ b/modules/core/src/test/scala/consul4s/BaseSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 trait BaseSpec extends AnyWordSpec with Matchers with EitherValues with Eventually {
   def runEither(fa: => Either[ResponseError[Exception], Assertion]): Assertion =
     fa.fold(
-      error => fail(error.body),
+      error => fail(error),
       _ => succeed
     )
 

--- a/modules/core/src/test/scala/consul4s/ConsulContainer.scala
+++ b/modules/core/src/test/scala/consul4s/ConsulContainer.scala
@@ -10,6 +10,6 @@ object ConsulContainer {
 
   case class Def()
       extends GenericContainer.Def[ConsulContainer](
-        new ConsulContainer(GenericContainer(dockerImage = "consul:1.7.3", exposedPorts = Seq(8500), waitStrategy = waitStrategy))
+        new ConsulContainer(GenericContainer(dockerImage = "consul:1.9.3", exposedPorts = Seq(8500), waitStrategy = waitStrategy))
       )
 }

--- a/modules/json4s/src/main/scala/consul4s/json4s/package.scala
+++ b/modules/json4s/src/main/scala/consul4s/json4s/package.scala
@@ -69,7 +69,7 @@ package object json4s
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -83,7 +83,7 @@ package object json4s
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -95,7 +95,7 @@ package object json4s
           res => Right(res)
         )
       } else {
-        Left[ResponseError[Exception], A](HttpError(str))
+        Left[ResponseError[Exception], A](HttpError(str, meta.code))
       }
     }
 

--- a/modules/spray-json/src/main/scala/consul4s/sprayJson/package.scala
+++ b/modules/spray-json/src/main/scala/consul4s/sprayJson/package.scala
@@ -46,7 +46,7 @@ package object sprayJson
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -59,7 +59,7 @@ package object sprayJson
       } else if (meta.code.code == 404) {
         Right(None)
       } else {
-        Left[ResponseError[Exception], Option[A]](HttpError(str))
+        Left[ResponseError[Exception], Option[A]](HttpError(str, meta.code))
       }
     }
 
@@ -68,7 +68,7 @@ package object sprayJson
       if (meta.code.code == 200 || meta.code.code == 409) {
         Try(deserializeJson[A].apply(str)).fold(err => Left(DeserializationError(str, new Exception(err))), res => Right(res))
       } else {
-        Left[ResponseError[Exception], A](HttpError(str))
+        Left[ResponseError[Exception], A](HttpError(str, meta.code))
       }
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.10
+sbt.version = 1.4.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")


### PR DESCRIPTION
First things first: thank you @nryanov for this library! Great job, I was actually thinking of writing this myself just a few days before you published it, but shortly after I had another look and found this, it saved me a lot of work. 
I'm using consul4s at work, so I want to contribute back with a small PR to update versions :) 

A couple of notable changes:
- `Header.notValidated(..., ...)` was deprecated (and removed from sttp-model 1.2.0), switched to `Header(..., ...)` as [suggested by the library](https://github.com/softwaremill/sttp-model/blob/defc8d3378ed061458b0332a5cf5b09da8d39e3e/core/shared/src/main/scala/sttp/model/Header.scala#L58)
-  `ResponseError` and its subclass `HttpError` were refactored in sttp-model 1.2.0 in a way which included a breaking change (adding a field to HttpError case class). 
So all its usages had to be adapted from `HttpError(str)` to `HttpError(str, meta.code)`